### PR TITLE
Auto-deploy from travis on new tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,12 @@ install:
 - pip install tox
 script:
 - tox
+deploy:
+  provider: pypi
+  user: ddanier
+  password:
+    secure: ""
+  on:
+    tags: true
+    repo: team23/django_backend
+    condition: "$TOXENV = py27-18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: python
 python: 2.7
 sudo: false
 cache:
-    - pip
+- pip
 env:
-    - TOXENV=py27-16
-    - TOXENV=py27-18
-    - TOXENV=pypy-16
-    - TOXENV=pypy-18
+- TOXENV=py27-16
+- TOXENV=py27-18
+- TOXENV=pypy-16
+- TOXENV=pypy-18
 install:
-    - pip install tox
+- pip install tox
 script:
-    - tox
+- tox


### PR DESCRIPTION
I would like to add auto deployments through Travis whenever a new tag is pushed. Travis will then run the testsuite and auto deploy the new tagged version to PyPI when the "py27-18" test environment successfully passes.

To enable the auto deploy you need to perform the following steps:

- Merge this PR
- Install the travis CLI tool
- Run the following command in the repo's root: `travis encrypt --add deploy.password`
- Commit changes made to `.travis.yml`

Also see the Travis guide on this topic: https://docs.travis-ci.com/user/deployment/pypi

Auto-deploying would allow me to push new tags to Github and issue a release without bugging you on every single time :beers: 